### PR TITLE
fix: don't throw when there is one good commit and one bad commit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const IGNORED_ERROR_REPORT_SCHEMA = [
 ];
 
 function doesReportMatchErrorSchema(report, schema) {
-  return report.errors.length === schema.length
+  return report.errors.length > 0
     && report.errors.every(error => schema.includes(error.name));
 }
 
@@ -50,15 +50,19 @@ async function runCommitLint(commit) {
       hasErrorReports = true;
       orderedValidAndErrorReports.push(report);
       errorCount++;
+    } else {
+      orderedValidAndErrorReports.push({
+        ...report,
+        valid: true,
+        errors: [],
+        warnings: [],
+      });
     }
   }
 
-  let shouldRemoveIgnoredErrors = hasErrorReports || hasValidReports;
   let didFailLinting = hasErrorReports || !hasValidReports;
 
-  if (shouldRemoveIgnoredErrors) {
-    reports = orderedValidAndErrorReports;
-  }
+  reports = orderedValidAndErrorReports;
 
   if (didFailLinting) {
     process.exitCode = 1;

--- a/test/fixtures/commitlint.config.js
+++ b/test/fixtures/commitlint.config.js
@@ -3,5 +3,6 @@
 module.exports = {
   rules: {
     'type-case': [2, 'always', 'lower-case'],
+    'subject-empty': [2, 'never'],
   },
 };


### PR DESCRIPTION
when I added `'subject-empty': [2, 'never'],` to test fixture commitlint.config.js without any other code changes - test `succeeds when one good commit and one bad subject-empty commit on branch` started to fail

```
  1) Index
       default branch
         succeeds when one good commit and one bad subject-empty commit on branch:
     ExecaError: Command failed with exit code 1: /Users/prasad/vscode/public/commitlint/bin/index.js

⧗   input: chore: bar
✔   found 0 problems, 0 warnings
⧗   input: chore:
✖   subject may not be empty [subject-empty]

✖   found 1 problems, 0 warnings
```

It started throwing which is not supposed to. 

with my change

```
orderedValidAndErrorReports.push({
        ...report,
        valid: true,
        errors: [],
        warnings: [],
      });
```

below report will be modified and reported as valid

```
  -{
      -  valid: false,
      -  errors: [
      -    {
      -      level: 2,
      -      valid: false,
      -      name: 'subject-empty',
      -      message: 'subject may not be empty'
      -    }
      -  ],
      -  warnings: [],
      -  input: 'chore:'
      -}
```

