### PR TITLE
chore: use https repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/CrowdStrike/commitlint.git"
+    "url": "git+https://github.com/CrowdStrike/commitlint.git"
   },
   "keywords": [
     "conventional-changelog"


### PR DESCRIPTION
Summary
- Use the public HTTPS GitHub URL for package repository metadata.
- Leave package name, version, dependencies, and runtime code unchanged.

Verification
- node -e "const p=require('./package.json'); if (p.repository.url !== 'git+https://github.com/CrowdStrike/commitlint.git') throw new Error(p.repository.url)"
- git diff --check